### PR TITLE
Fixed image to fully cover website page in CSS

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -1,4 +1,6 @@
 body {
     background-image: url('./images/Clouds.jpg');
     background-repeat: no-repeat;
+    background-attachment: fixed;
+    background-size: cover;
 }


### PR DESCRIPTION
Added additional properties in CSS of .body to make the background image fully cover and not repeat.